### PR TITLE
ovh-dyndns: use https for update call

### DIFF
--- a/ovh-dyndns/Dockerfile
+++ b/ovh-dyndns/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Ambroise Maupate <ambroise@rezo-zero.com>
 ENV HOST=""
 ENV LOGIN=""
 ENV PASSWORD=""
-ENV ENTRYPOINT="http://www.ovh.com/nic/update"
+ENV ENTRYPOINT="https://www.ovh.com/nic/update"
 ENV NSSERVER="8.8.8.8"
 
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \


### PR DESCRIPTION
Hi, stumbled upon this OVH DynDNS update image and it looks very useful, I'd like to use it 👍 

I just noticed that the update call uses HTTP though, which I'm not a super fan of. This PR would change this call to HTTPS.

Thanks!